### PR TITLE
Fix stuck while loop with spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export function highlight (text: string, searchTerm: string, options: HighlightO
   const CSSClass = options.CSSClass ?? defaultOptions.CSSClass
   const regexFlags = caseSensitive ? 'g' : 'gi'
   const boundary = wholeWords ? '\\b' : ''
-  const searchTerms = (caseSensitive ? searchTerm : searchTerm.toLowerCase()).split(/\s+/).join('|')
+  const searchTerms = (caseSensitive ? searchTerm : searchTerm.toLowerCase()).trim().split(/\s+/).join('|')
   const regex = new RegExp(`${boundary}${searchTerms}${boundary}`, regexFlags)
   const positions: Array<{ start: number, end: number }> = []
   const highlightedParts: string[] = []


### PR DESCRIPTION
When `searchterm` has a space at the beginning or the end the while loop seems to get stuck. So if `searchTerms` is formatted like `word|` / `|word` / `word|word2|`.

Running trim on the string first avoids this by ensuring there's no leading or trailing pipe.