### PR TITLE
Add ability to highlight full word on partial match

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -139,6 +139,21 @@ describe("custom configuration", () => {
       expectedResult
     );
   });
+
+  it("should not highlight anything on 0 matches on a partial match - full word highlight strategy when the search term is nothing", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    const searchTerm = "";
+    const expectedResult = "The quick brown fox jumps over the lazy dog";
+
+    const highlighter = new Highlight({
+      strategy: "partial match - full word highlight",
+    });
+
+    assert.strictEqual(
+      highlighter.highlight(text, searchTerm).HTML,
+      expectedResult
+    );
+  });
 });
 
 describe("highlight function - infinite loop protection", () => {
@@ -234,7 +249,7 @@ describe("special characters", () => {
   });
 });
 
-describe("empty example", () => {
+describe("null example", () => {
   // even though it is not expected we should make sure it won't break
   it("should not break when text is null", () => {
     const searchTerm = "C";
@@ -243,13 +258,13 @@ describe("empty example", () => {
     // @ts-expect-error
     assert.strictEqual(highlighter.highlight(null, searchTerm).HTML, "");
   });
-  it("should not break when search term is null", () => {
+  it("should not break when text and search term is null", () => {
     const highlighter = new Highlight();
 
     assert.strictEqual(
       // @ts-expect-error
       highlighter.highlight(null, null).HTML,
-      '<mark class="orama-highlight"></mark>'
+      ""
     );
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, it } from "bun:test";
 import assert from "node:assert";
 import sinon from "sinon";
 import { Highlight } from "./index.js";
@@ -110,13 +110,29 @@ describe("custom configuration", () => {
     );
   });
 
-  it("should correctly highlight whole words only", () => {
+  it("should correctly highlight whole word matches only", () => {
     const text = "The quick brown fox jumps over the lazy dog";
     const searchTerm = "fox jump";
     const expectedResult =
       'The quick brown <mark class="orama-highlight">fox</mark> jumps over the lazy dog';
 
-    const highlighter = new Highlight({ wholeWords: true });
+    const highlighter = new Highlight({ strategy: "whole word match" });
+
+    assert.strictEqual(
+      highlighter.highlight(text, searchTerm).HTML,
+      expectedResult
+    );
+  });
+
+  it("should correctly highlight whole words on partial matches only", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    const searchTerm = "fox jump";
+    const expectedResult =
+      'The quick brown <mark class="orama-highlight">fox</mark> <mark class="orama-highlight">jumps</mark> over the lazy dog';
+
+    const highlighter = new Highlight({
+      strategy: "partial match - full word highlight",
+    });
 
     assert.strictEqual(
       highlighter.highlight(text, searchTerm).HTML,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "bun:test";
+import { describe, it, beforeEach, afterEach } from "bun:test";
 import assert from "node:assert";
 import sinon from "sinon";
 import { Highlight } from "./index.js";
@@ -126,9 +126,9 @@ describe("custom configuration", () => {
 
   it("should correctly highlight whole words on partial matches only", () => {
     const text = "The quick brown fox jumps over the lazy dog";
-    const searchTerm = "fox jump";
+    const searchTerm = "fo umps ve";
     const expectedResult =
-      'The quick brown <mark class="orama-highlight">fox</mark> <mark class="orama-highlight">jumps</mark> over the lazy dog';
+      'The quick brown <mark class="orama-highlight">fox</mark> <mark class="orama-highlight">jumps</mark> <mark class="orama-highlight">over</mark> the lazy dog';
 
     const highlighter = new Highlight({
       strategy: "partial match - full word highlight",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, it } from "bun:test";
 import assert from "node:assert";
 import sinon from "sinon";
-import { Highlight } from "./index.js";
+import { Highlight, highlightStrategy } from "./index.js";
 
 describe("default configuration", () => {
   it("should correctly highlight a text", () => {
@@ -116,7 +116,7 @@ describe("custom configuration", () => {
     const expectedResult =
       'The quick brown <mark class="orama-highlight">fox</mark> jumps over the lazy dog';
 
-    const highlighter = new Highlight({ strategy: "whole word match" });
+    const highlighter = new Highlight({ strategy: highlightStrategy.WHOLE_WORD_MATCH });
 
     assert.strictEqual(
       highlighter.highlight(text, searchTerm).HTML,
@@ -131,7 +131,7 @@ describe("custom configuration", () => {
       'The quick brown <mark class="orama-highlight">fox</mark> <mark class="orama-highlight">jumps</mark> <mark class="orama-highlight">over</mark> the lazy dog';
 
     const highlighter = new Highlight({
-      strategy: "partial match - full word highlight",
+      strategy: highlightStrategy.PARTIAL_MATCH_FULL_WORD,
     });
 
     assert.strictEqual(
@@ -140,13 +140,13 @@ describe("custom configuration", () => {
     );
   });
 
-  it("should not highlight anything on 0 matches on a partial match - full word highlight strategy when the search term is nothing", () => {
+  it("should not highlight anything on 0 matches on a partial match, full word highlight strategy when the search term is nothing", () => {
     const text = "The quick brown fox jumps over the lazy dog";
     const searchTerm = "";
     const expectedResult = "The quick brown fox jumps over the lazy dog";
 
     const highlighter = new Highlight({
-      strategy: "partial match - full word highlight",
+      strategy: highlightStrategy.PARTIAL_MATCH_FULL_WORD,
     });
 
     assert.strictEqual(

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,11 +33,18 @@ export class Highlight {
     this._searchTerm = searchTerm ?? "";
     this._originalText = text ?? "";
 
+    if (!this._searchTerm || !this._originalText) {
+      this._positions = [];
+      this._HTML = this._originalText;
+      return this;
+    }
+
+    const HTMLTag = this.options.HTMLTag ?? defaultOptions.HTMLTag;
+    const CSSClass = this.options.CSSClass ?? defaultOptions.CSSClass;
+
     const caseSensitive =
       this.options.caseSensitive ?? defaultOptions.caseSensitive;
     const strategy = this.options.strategy ?? defaultOptions.strategy;
-    const HTMLTag = this.options.HTMLTag ?? defaultOptions.HTMLTag;
-    const CSSClass = this.options.CSSClass ?? defaultOptions.CSSClass;
     const regexFlags = caseSensitive ? "g" : "gi";
     const searchTerms = this.escapeRegExp(
       caseSensitive ? this._searchTerm : this._searchTerm.toLowerCase()

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export interface HighlightOptions {
   caseSensitive?: boolean;
   strategy?:
     | "whole word match"
-    | "partial match - partial highlight"
+    | "partial match"
     | "partial match - full word highlight";
   HTMLTag?: string;
   CSSClass?: string;
@@ -13,7 +13,7 @@ type Positions = Position[];
 
 const defaultOptions: Required<HighlightOptions> = {
   caseSensitive: false,
-  strategy: "partial match - partial highlight",
+  strategy: "partial match",
   HTMLTag: "mark",
   CSSClass: "orama-highlight",
 };
@@ -49,10 +49,10 @@ export class Highlight {
     let regex: RegExp;
     if (strategy === "whole word match") {
       regex = new RegExp(`\\b${searchTerms}\\b`, regexFlags);
-    } else if (strategy === "partial match - partial highlight") {
+    } else if (strategy === "partial match") {
       regex = new RegExp(searchTerms, regexFlags);
     } else if (strategy === "partial match - full word highlight") {
-      regex = new RegExp(`\\b(${searchTerms})[^\\s]*`, regexFlags);
+      regex = new RegExp(`\\b[^\\s]*(${searchTerms})[^\\s]*\\b`, regexFlags);
     } else {
       throw new Error("Invalid highlighter strategy");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
+export const highlightStrategy = {
+  WHOLE_WORD_MATCH: "wholeWordMatch",
+  PARTIAL_MATCH: "partialMatch",
+  PARTIAL_MATCH_FULL_WORD: "partialMatchFullWord",
+} as const;
+
+export type HighlightStrategy =
+  (typeof highlightStrategy)[keyof typeof highlightStrategy];
+
 export interface HighlightOptions {
   caseSensitive?: boolean;
-  strategy?:
-    | "whole word match"
-    | "partial match"
-    | "partial match - full word highlight";
+  strategy?: HighlightStrategy;
   HTMLTag?: string;
   CSSClass?: string;
 }
@@ -13,7 +19,7 @@ type Positions = Position[];
 
 const defaultOptions: Required<HighlightOptions> = {
   caseSensitive: false,
-  strategy: "partial match",
+  strategy: highlightStrategy.PARTIAL_MATCH,
   HTMLTag: "mark",
   CSSClass: "orama-highlight",
 };
@@ -54,11 +60,11 @@ export class Highlight {
       .join("|");
 
     let regex: RegExp;
-    if (strategy === "whole word match") {
+    if (strategy === highlightStrategy.WHOLE_WORD_MATCH) {
       regex = new RegExp(`\\b${searchTerms}\\b`, regexFlags);
-    } else if (strategy === "partial match") {
+    } else if (strategy === highlightStrategy.PARTIAL_MATCH) {
       regex = new RegExp(searchTerms, regexFlags);
-    } else if (strategy === "partial match - full word highlight") {
+    } else if (strategy === highlightStrategy.PARTIAL_MATCH_FULL_WORD) {
       regex = new RegExp(`\\b[^\\s]*(${searchTerms})[^\\s]*\\b`, regexFlags);
     } else {
       throw new Error("Invalid highlighter strategy");


### PR DESCRIPTION
I am currently using `@orama/orama` in a personal project and was looking to use `@orama/plugin-match-highlight` plugin but noticed that the README for the plugin said that it would be deprecated in favour of this library.

I found this library to be alot easier to use than the plugin for generating highlights! However I noticed the ability to highlight full words on partial matches was missing and so I have attempted to add this in.

I'm not especially attached to the way I have approached any of this so please do feel free to ask that I change anything for it to fit any guidelines or internal discussions.